### PR TITLE
Add a composer suggest line for Symfony Yaml package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,5 +38,8 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "suggest": {
+        "symfony/yaml": "Allows for parsing of YAML theme info and change log files"
+    }
 }


### PR DESCRIPTION
As default YAML files are used for Changelogs however if you don't have the Symfony Yaml package, setting and loading theme data fails.

This pull request adds a simple suggest to composer to increase visibility that this package is needed for yaml file configs.