### PR TITLE
Add BeforeThemeLoaded and AfterThemeLoaded Events

### DIFF
--- a/src/Events/AfterThemeLoadedEvent.php
+++ b/src/Events/AfterThemeLoadedEvent.php
@@ -28,6 +28,7 @@ class AfterThemeLoadedEvent
     {
         $this->manager = $manager;
         $this->theme = $theme;
+        $this->level = $level;
     }
 
     /**

--- a/src/Events/AfterThemeLoadedEvent.php
+++ b/src/Events/AfterThemeLoadedEvent.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Shipu\Themevel\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+use Shipu\Themevel\Managers\Theme;
+
+class AfterThemeLoadedEvent
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public $manager;
+    public $current;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(Theme $manager, $theme, $level)
+    {
+        $this->manager = $manager;
+        $this->theme = $theme;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('theme');
+    }
+}

--- a/src/Events/BeforeThemeLoadedEvent.php
+++ b/src/Events/BeforeThemeLoadedEvent.php
@@ -28,6 +28,7 @@ class BeforeThemeLoadedEvent
     {
         $this->manager = $manager;
         $this->theme = $theme;
+        $this->level = $level;
     }
 
     /**

--- a/src/Events/BeforeThemeLoadedEvent.php
+++ b/src/Events/BeforeThemeLoadedEvent.php
@@ -12,7 +12,7 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 
 use Shipu\Themevel\Managers\Theme;
 
-class ThemeLoadedEvent
+class BeforeThemeLoadedEvent
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
@@ -24,7 +24,7 @@ class ThemeLoadedEvent
      *
      * @return void
      */
-    public function __construct(Theme $manager, $theme)
+    public function __construct(Theme $manager, $theme, $level)
     {
         $this->manager = $manager;
         $this->theme = $theme;

--- a/src/Events/ThemeLoadedEvent.php
+++ b/src/Events/ThemeLoadedEvent.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Shipu\Themevel\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+use Shipu\Themevel\Managers\Theme;
+
+class ThemeLoadedEvent
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public $manager;
+    public $current;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(Theme $manager, $theme)
+    {
+        $this->manager = $manager;
+        $this->theme = $theme;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('theme');
+    }
+}

--- a/src/Managers/Theme.php
+++ b/src/Managers/Theme.php
@@ -9,7 +9,8 @@ use Illuminate\View\ViewFinderInterface;
 use Noodlehaus\Config;
 use Shipu\Themevel\Contracts\ThemeContract;
 use Shipu\Themevel\Exceptions\ThemeNotFoundException;
-use Shipu\Themevel\Events\ThemeLoadedEvent;
+use Shipu\Themevel\Events\BeforeThemeLoadedEvent;
+use Shipu\Themevel\Events\AfterThemeLoadedEvent;
 
 class Theme implements ThemeContract
 {
@@ -266,10 +267,11 @@ class Theme implements ThemeContract
      * Map view map for particular theme.
      *
      * @param string $theme
+     * @param int $level
      *
-     * @return void
+     * @return null|bool
      */
-    private function loadTheme($theme)
+    private function loadTheme($theme, $level = 0)
     {
         if (is_null($theme)) {
             return;
@@ -281,7 +283,12 @@ class Theme implements ThemeContract
             return;
         }
 
-        $this->loadTheme($themeInfo->get('parent'));
+        $beforeResponse = event(new BeforeThemeLoadedEvent($this, $themeInfo, $level));
+        if ($beforeResponse === false) {
+            return false;
+        }
+
+        $this->loadTheme($themeInfo->get('parent'), $level + 1);
 
         $viewPath = $themeInfo->get('path').'/'.$this->config['theme.folders.views'];
         $langPath = $themeInfo->get('path').'/'.$this->config['theme.folders.lang'];
@@ -294,6 +301,8 @@ class Theme implements ThemeContract
         }
         $this->lang->addNamespace($themeInfo->get('name'), $langPath);
 
-        event(new ThemeLoadedEvent($this, $themeInfo));
+        event(new AfterThemeLoadedEvent($this, $themeInfo, $level));
+
+        return true;
     }
 }

--- a/src/Managers/Theme.php
+++ b/src/Managers/Theme.php
@@ -9,6 +9,7 @@ use Illuminate\View\ViewFinderInterface;
 use Noodlehaus\Config;
 use Shipu\Themevel\Contracts\ThemeContract;
 use Shipu\Themevel\Exceptions\ThemeNotFoundException;
+use Shipu\Themevel\Events\ThemeLoadedEvent;
 
 class Theme implements ThemeContract
 {
@@ -292,5 +293,7 @@ class Theme implements ThemeContract
             $this->finder->prependNamespace($themeInfo->get('type'), $viewPath);
         }
         $this->lang->addNamespace($themeInfo->get('name'), $langPath);
+
+        event(new ThemeLoadedEvent($this, $themeInfo));
     }
 }


### PR DESCRIPTION
Added events to respond to Theme loading.  The BeforeThemeLoaded event will not allow a theme to be loaded if it returns false.

The event is also passed the $level so the user can tell if it is a parent/grandparent, etc.