### PR TITLE
fix: changed dangerous 777 permission to 755

### DIFF
--- a/src/Console/ThemeGeneratorCommand.php
+++ b/src/Console/ThemeGeneratorCommand.php
@@ -192,7 +192,7 @@ class ThemeGeneratorCommand extends Command
     protected function makeDir($directory)
     {
         if (!$this->files->isDirectory($directory)) {
-            $this->files->makeDirectory($directory, 0777, true);
+            $this->files->makeDirectory($directory, 0775, true);
         }
     }
 

--- a/src/Console/ThemeGeneratorCommand.php
+++ b/src/Console/ThemeGeneratorCommand.php
@@ -192,7 +192,7 @@ class ThemeGeneratorCommand extends Command
     protected function makeDir($directory)
     {
         if (!$this->files->isDirectory($directory)) {
-            $this->files->makeDirectory($directory, 0775, true);
+            $this->files->makeDirectory($directory, 0755, true);
         }
     }
 


### PR DESCRIPTION
With the permission set to 777, everyone would be able to read, write and execute on the file.

An attacker with access would be able to alter the file.