### PR TITLE
allow installing with newer yaml version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "hassankhan/config": "^2.1",
-        "symfony/yaml": "^5.2"
+        "symfony/yaml": "^5.2 || ^6.0"
     },
     "require-dev": {
         "graham-campbell/testbench": "^3.3",


### PR DESCRIPTION
This allows installing other packages such as `psalm/plugin-laravel` that have dependencies that require yaml 6.x. Many Symfony components work with 5.x and 6.x, and from them it looks like supporting multiple versions seems to not require any changes.